### PR TITLE
Async

### DIFF
--- a/callhub/callhub.py
+++ b/callhub/callhub.py
@@ -155,15 +155,32 @@ class CallHub:
         fetched = 0
         contacts_url = "https://api.callhub.io/v1/contacts/"
         contact_list = []
-        while fetched < limit:
-            contacts = self.session.get(contacts_url).json()
-            print("{}/{} fetched. ({}%)".format(fetched, min(limit, contacts["count"]), round(fetched*100 / min(limit, contacts["count"]), 1)))
-            fetched += len(contacts["results"])
+        first_page = self.session.get(contacts_url).result().json()
+
+        # Calculate number of pages
+        page_size = len(first_page["results"])
+        num_pages = min(math.ceil(first_page["count"]/page_size), math.ceil(limit/page_size))
+        requests = []
+        fetched = 0
+        for i in range(1, num_pages+1):
+            fetched += page_size
+            print("Sent requests for {}/{} contacts ({}%)".format(fetched, min(limit, first_page["count"]),
+                                                round(fetched * 100 / min(limit, first_page["count"]), 1)))
+            requests.append(self.session.get(contacts_url, params={"page": i}))
+
+        print("Resolving requests")
+        for i, request in enumerate(requests):
+            current_contact = i * page_size
+            total_contacts = len(requests) * page_size
+            if current_contact % 100 == 0:
+                print("Resolving responses for {}/{} contacts ({}%)".format(current_contact, total_contacts,
+                                                                            round(current_contact * 100 / total_contacts)))
+            request = request.result()
+            contacts = request.json()
             contact_list += contacts["results"]
-            if contacts["next"]:
-                contacts_url = contacts["next"]
-            else:
-                break
+
+            if request.status_code != 200:
+                raise RuntimeError("Request {} status code {}".format(request.text,request.status_code))
 
         contact_list = contact_list[:limit]
         return contact_list

--- a/tests/tests_live.py
+++ b/tests/tests_live.py
@@ -27,5 +27,9 @@ class TestInit(unittest.TestCase):
         contacts = [{"first name": "James", "contact": 5555555555}, {"last name": "Brunet", "contact": 1234567890}]
         self.assertEqual(self.callhub._collect_fields(contacts), {"first name", "last name", "contact"})
 
+    @classmethod
+    def tearDownClass(cls):
+        cls.callhub.session.close()
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/tests_live.py
+++ b/tests/tests_live.py
@@ -11,17 +11,17 @@ class TestInit(unittest.TestCase):
         cls.callhub = CallHub()
 
     def test_agent_leaderboard(self):
-        self.callhub.agent_leaderboard("2019-12-30", "2020-12-30")
+        print(self.callhub.agent_leaderboard("2019-12-30", "2020-12-30"))
 
     def test_bulk_create(self):
         # Tests ratelimit
         self.callhub.bulk_create(
             2325931969109558581,
-            [{"first name": "james", "phone number": "5555555555"}],
+            [{"first name": "james", "phone number": "3333333333"}],
             "CA")
 
     def test_fields(self):
-        self.callhub.fields()
+        print(self.callhub.fields())
 
     def test_collect_fields(self):
         contacts = [{"first name": "James", "contact": 5555555555}, {"last name": "Brunet", "contact": 1234567890}]

--- a/tests/tests_mock.py
+++ b/tests/tests_mock.py
@@ -33,7 +33,7 @@ class TestInit(unittest.TestCase):
 
 
     def test_agent_leaderboard(self):
-        self.callhub.session.get.return_value.json.return_value = {
+        self.callhub.session.get.return_value.result.return_value.json.return_value = {
             "plot_data": [
                 {
                     'connecttime': 3300,
@@ -63,7 +63,7 @@ class TestInit(unittest.TestCase):
 
         self.callhub.fields = MagicMock(return_value={"first name": 0, "phone number": 1})
         self.callhub.session.post = MagicMock()
-        self.callhub.session.post.return_value.json.return_value = {
+        self.callhub.session.post.return_value.result.return_value.json.return_value = {
             "message": "'Import in progress. You will get an email when import is complete'"}
         result = self.callhub.bulk_create(
             2325931969109558581,
@@ -83,7 +83,7 @@ class TestInit(unittest.TestCase):
     def test_bulk_create_api_exceeded_or_other_failure(self):
         self.callhub.fields = MagicMock(return_value={"first name": 0, "phone number": 1})
         self.callhub.session.post = MagicMock()
-        self.callhub.session.post.return_value.json.return_value = {
+        self.callhub.session.post.return_value.result.return_value.json.return_value = {
             "detail": "Request was throttled."}
         self.assertRaises(RuntimeError,
                           self.callhub.bulk_create,
@@ -91,7 +91,7 @@ class TestInit(unittest.TestCase):
                           [{"first name": "james", "phone number": "5555555555"}],
                           "CA"
                           )
-        self.callhub.session.post.return_value.json.return_value = {
+        self.callhub.session.post.return_value.result.return_value.json.return_value = {
             "NON STANDARD KEY": "YOU MESSED UP FOR SOME REASON"}
         self.assertRaises(RuntimeError,
                           self.callhub.bulk_create,
@@ -128,7 +128,7 @@ class TestInit(unittest.TestCase):
 
     def test_fields(self):
         self.callhub.session.get = MagicMock()
-        self.callhub.session.get.return_value.json.return_value = {'count': 4, 'results':
+        self.callhub.session.get.return_value.result.return_value.json.return_value = {'count': 4, 'results':
             [{'id': 0, 'name': 'phone number'}, {'id': 1, 'name': 'mobile number'},
              {'id': 2, 'name': 'last name'}, {'id': 3, 'name': 'first name'}]}
         self.assertEqual(self.callhub.fields(),


### PR DESCRIPTION
## Status
**READY**

## Description
Moving from requests.session to requests_futures.sessions makes it possible to do asynchronous requests to the CallHub API. This is critical to ensure that repetitive calls execute quickly. Synchronous requests rarely go faster than 1 request a second, but CallHub's API limit for most requests is much higher (20/s), and using requests_futures.sessions allows us to do easy, readable async calls that can hit that limit.

All functions on this branch now use requests_futures.sessions, and get_contacts now leverages asynchronous calls to pull a list of contacts faster.

This change is also helpful for creating a bulk_add_dnc feature.

## Todos
- [ ] Tests
